### PR TITLE
generalize packer config filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ packer build -color=false -var aws_region=us-west-2 -var aws_ssh_username=ubuntu
 ```
 Fake packer intercepts it because it is on the PATH and then calls:
 ```
-/opt/packer build -color=false -var aws_region=us-west-2 -var aws_ssh_username=ubuntu -var aws_instance_type=t2.micro -var aws_source_ami=ami-d732f0b7 -var aws_target_ami=nginx-all-20160721161956-ubuntu -var aws_associate_public_ip_address=true -var package_type=deb -var packages=nginx -var configDir=/opt/rosco/config/packer /opt/rosco/config/packer/aws-ebs-west-2.json
+/opt/packer build -color=false -var aws_region=us-west-2 -var aws_ssh_username=ubuntu -var aws_instance_type=t2.micro -var aws_source_ami=ami-d732f0b7 -var aws_target_ami=nginx-all-20160721161956-ubuntu -var aws_associate_public_ip_address=true -var package_type=deb -var packages=nginx -var configDir=/opt/rosco/config/packer /opt/rosco/config/packer/aws-ebs-us-west-2.json
 ```
-aws-ebs-west-2.json and aws-ebs-east-1.json have their specific vpc and subnet info.
+aws-ebs-us-west-2.json and aws-ebs-us-east-1.json have their specific vpc and subnet info.
+
+## Advanced Cases
+
+If you have a customized packer config (for example customXYZ.json instead of aws-ebs.json) the methodology is very similar.
+```
+./install.sh customXYZ
+```
+or
+```
+./install.sh customXYZ.json
+```
+This creates files customXYZ-us-west-2.json and customXYZ-us-east-1.json. Set their specific vpc and subnet info.
+Additional configurations many be generated even without the install.sh script: `cp customA.json customA-us-west-1.json`.
+
+ 

--- a/install.sh
+++ b/install.sh
@@ -5,13 +5,20 @@ rm -f /usr/local/bin/packer
 mv wrappa /usr/local/bin/packer
 
 #install packer
-wget https://releases.hashicorp.com/packer/0.10.1/packer_0.10.1_linux_amd64.zip
-unzip packer_0.10.1_linux_amd64.zip
+wget https://releases.hashicorp.com/packer/0.12.2/packer_0.12.2_linux_amd64.zip
+unzip packer_0.12.2_linux_amd64.zip
 mv packer /opt/packer
+
+#The name of the file is probably aws-ebs.json, however if an argument is provided then use that instead.
+CONFIGNAME=aws-ebs
+if [ ! -z "$1" ]; then
+    CONFIGNAME=`basename -s .json $1`
+fi
 
 #duplicate aws-ebs.json for each region. They will need to be manually filled out for correct region vpc-id and subnet-id
 
 for REGION in us-east-1 us-west-1 us-west-2 ap-south-1 ap-northeast-2 ap-southeast-1 ap-southeast-2 ap-northeast-1 eu-central-1 eu-west-1 sa-east-1
 do
-	cp /opt/rosco/config/packer/aws-ebs.json /opt/rosco/config/packer/aws-ebs-$REGION.json
+	cp /opt/rosco/config/packer/$CONFIGNAME.json /opt/rosco/config/packer/$CONFIGNAME-$REGION.json
 done
+

--- a/wrappa
+++ b/wrappa
@@ -3,7 +3,9 @@
 ARGS="$@"
 REGION=$4
 IFS='=' read -ra REG <<< "$REGION"
-NEWCONFIG="aws-ebs-${REG[1]}.json"
-ARGS="${ARGS/aws-ebs.json/$NEWCONFIG}"
+ORIGCONFIG=`basename -s .json "${@: -1}"`
+NEWCONFIG="$ORIGCONFIG-${REG[1]}.json"
+ARGS="${ARGS/$ORIGCONFIG.json/$NEWCONFIG}"
 
 /opt/packer $ARGS
+


### PR DESCRIPTION
The file aws-ebs.json can now be _anything_.json , allowing for custom packer configs. 
Let me know what you think.